### PR TITLE
Bug 643636: error notification bar does not popup panel

### DIFF
--- a/extensions/firefox-share/src/modules/panel.js
+++ b/extensions/firefox-share/src/modules/panel.js
@@ -658,7 +658,7 @@ sharePanel.prototype = {
             let nb = self.gBrowser.getNotificationBox();
             nb.removeNotification(nb.getNotificationWithValue("mozilla-f1-share-error"));
             self.window.setTimeout(function () {
-              ffshare.togglePanel();
+              self.ffshare.togglePanel();
             }, 0);
           }
         }];


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=643636
