### PR TITLE
Bug 644709 - sharePanel.shutdown() isn't called. r?mixedpuppy

### DIFF
--- a/extensions/firefox-share/src/modules/main.js
+++ b/extensions/firefox-share/src/modules/main.js
@@ -356,6 +356,8 @@ FFShare.prototype = {
         this.window.removeEventListener('tabviewhide', this.tabViewHideListener, false);
         this.tabViewShowListener = null;
         this.tabViewHideListener = null;
+
+        this.sharePanel.unload();
     },
 
     onInstallUpgrade: function (version) {

--- a/extensions/firefox-share/src/modules/panel.js
+++ b/extensions/firefox-share/src/modules/panel.js
@@ -123,7 +123,7 @@ sharePanel.prototype = {
     );
   },
 
-  shutdown: function () {
+  unload: function () {
     Services.obs.removeObserver(this, 'content-document-global-created');
     let webProgress = this.browser.webProgress;
     webProgress.removeProgressListener(this.stateProgressListener);


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=644709
