### PR TITLE
Initial support for X-Target-Domain and Retry-After for API calls. Needs 

### DIFF
--- a/web/dev/1/scripts/Contacts.js
+++ b/web/dev/1/scripts/Contacts.js
@@ -127,6 +127,7 @@ function ($,        object,         fn,         dispatch,   rdapi,   accounts) {
 
       rdapi('contacts/' + acct.domain, {
         type: 'POST',
+        domain: acct.domain,
         data: {
           username: acct.username,
           userid: acct.userid,

--- a/web/dev/1/scripts/Contacts.js
+++ b/web/dev/1/scripts/Contacts.js
@@ -153,6 +153,9 @@ function ($,        object,         fn,         dispatch,   rdapi,   accounts) {
         error: fn.bind(this, function (xhr, textStatus, errorThrown) {
           // does not matter what the error is, just eat it and hide
           // the UI showing a wait.
+          // If xhr.status === 503, could do a retry, and dispatch a
+          // 'serverErrorPossibleRetry', but wait for UX to be worked out
+          // in https://bugzilla.mozilla.org/show_bug.cgi?id=642653
           this.notifyCallbacks();
         })
       });

--- a/web/dev/1/scripts/rdapi.js
+++ b/web/dev/1/scripts/rdapi.js
@@ -30,8 +30,6 @@ define([ 'require', 'jquery', 'blade/object', 'blade/jig', 'friendly', 'isoDate'
 function (require,   $,        object,         jig,         friendly,   isoDate) {
 
     var rdapi,
-        csrfHeader = 'X-CSRF',
-        csrfRegExp = /csrf=([^\; ]+)/,
         targetDomainHeader = 'X-Target-Domain',
         contacts = {},
         jigFunctions = {
@@ -101,11 +99,6 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
         return options;
     }
 
-    function getCsrfToken() {
-        var token = csrfRegExp.exec(document.cookie);
-        return token && token[1] ? token[1] : null;
-    }
-
     function ajax(url, options) {
         options.url = config.baseUrl + config.apiPath + url;
 
@@ -118,8 +111,7 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
             }
         });
 
-        var oldSuccess = options.success,
-            csrfToken = getCsrfToken();
+        var oldSuccess = options.success;
 
         //Intercept any success calls to get a hold of contacts from
         //any API call that returns them. Also be sure to remember any
@@ -138,9 +130,6 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
         options.beforeSend = function (xhr) {
             if (options.domain) {
                 xhr.setRequestHeader(targetDomainHeader, options.domain);
-            }
-            if (csrfToken) {
-                xhr.setRequestHeader(csrfHeader, csrfToken);
             }
         };
 

--- a/web/dev/1/scripts/rdapi.js
+++ b/web/dev/1/scripts/rdapi.js
@@ -191,28 +191,9 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
                 }
             },
             error: function (xhr, textStatus, errorThrown) {
-                var retrySeconds = xhr.status === 503 &&
-                                   xhr.getResponseHeader('Retry-After'),
-                    html;
-
-                if (retrySeconds) {
-                    retrySeconds = parseInt(retrySeconds, 10);
-                    if (isNaN(retrySeconds)) {
-                        retrySeconds = null;
-                    }
-                }
-
                 if (options.emptyTemplate) {
-                    html = jig(options.emptyTemplate, errorThrown, options);
+                    var html = jig(options.emptyTemplate, errorThrown, options);
                     finishApiTemplating(html, options);
-                } else if (retrySeconds) {
-                    // TODO: Need to flesh this out a bit more, may need
-                    // to pause and show some UI before automatically retrying,
-                    // depending on the outcome of bug
-                    // https://bugzilla.mozilla.org/show_bug.cgi?id=642653
-                    setTimeout(function () {
-                        ajax(url, options);
-                    }, retrySeconds * 1000);
                 } else {
                     throw errorThrown;
                 }

--- a/web/dev/1/share/panel/index.js
+++ b/web/dev/1/share/panel/index.js
@@ -222,6 +222,7 @@ function (require,   $,        object,         fn,         rdapi,   oauth,
   function callSendApi() {
     rdapi('send', {
       type: 'POST',
+      domain: sendData.domain,
       data: sendData,
       success: function (json) {
         // {'message': u'Status is a duplicate.', 'provider': u'twitter.com'}

--- a/web/dev/1/share/panel/index.js
+++ b/web/dev/1/share/panel/index.js
@@ -265,7 +265,9 @@ function (require,   $,        object,         fn,         rdapi,   oauth,
           //var headerError = xhr.getResponseHeader('X-Error');
           reAuth();
         } else if (xhr.status === 503) {
-          showStatus('statusServerBusy');
+          dispatch.pub('serverErrorPossibleRetry', {
+            xhr: xhr
+          });
         } else if (xhr.status === 0) {
           showStatus('statusServerError');
         } else {
@@ -489,6 +491,13 @@ function (require,   $,        object,         fn,         rdapi,   oauth,
       //Listen to sendMessage events from the AccountPanels
       dispatch.sub('sendMessage', function (data) {
         sendMessage(data);
+      });
+
+      // Listen for 503 errors, could be a retry call, but for
+      // now, just show server error until better feedback is
+      // worked out in https://bugzilla.mozilla.org/show_bug.cgi?id=642653
+      dispatch.sub('serverErrorPossibleRetry', function (data) {
+        showStatus('statusServerBusy');
       });
 
       bodyDom = $('body');

--- a/web/dev/scripts/Contacts.js
+++ b/web/dev/scripts/Contacts.js
@@ -127,6 +127,7 @@ function ($,        object,         fn,         dispatch,   rdapi,   accounts) {
 
       rdapi('contacts/' + acct.domain, {
         type: 'POST',
+        domain: acct.domain,
         data: {
           username: acct.username,
           userid: acct.userid,

--- a/web/dev/scripts/Contacts.js
+++ b/web/dev/scripts/Contacts.js
@@ -153,6 +153,9 @@ function ($,        object,         fn,         dispatch,   rdapi,   accounts) {
         error: fn.bind(this, function (xhr, textStatus, errorThrown) {
           // does not matter what the error is, just eat it and hide
           // the UI showing a wait.
+          // If xhr.status === 503, could do a retry, and dispatch a
+          // 'serverErrorPossibleRetry', but wait for UX to be worked out
+          // in https://bugzilla.mozilla.org/show_bug.cgi?id=642653
           this.notifyCallbacks();
         })
       });

--- a/web/dev/scripts/rdapi.js
+++ b/web/dev/scripts/rdapi.js
@@ -30,8 +30,6 @@ define([ 'require', 'jquery', 'blade/object', 'blade/jig', 'friendly', 'isoDate'
 function (require,   $,        object,         jig,         friendly,   isoDate) {
 
     var rdapi,
-        csrfHeader = 'X-CSRF',
-        csrfRegExp = /csrf=([^\; ]+)/,
         targetDomainHeader = 'X-Target-Domain',
         contacts = {},
         jigFunctions = {
@@ -101,11 +99,6 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
         return options;
     }
 
-    function getCsrfToken() {
-        var token = csrfRegExp.exec(document.cookie);
-        return token && token[1] ? token[1] : null;
-    }
-
     function ajax(url, options) {
         options.url = config.baseUrl + config.apiPath + url;
 
@@ -118,8 +111,7 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
             }
         });
 
-        var oldSuccess = options.success,
-            csrfToken = getCsrfToken();
+        var oldSuccess = options.success;
 
         //Intercept any success calls to get a hold of contacts from
         //any API call that returns them. Also be sure to remember any
@@ -138,9 +130,6 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
         options.beforeSend = function (xhr) {
             if (options.domain) {
                 xhr.setRequestHeader(targetDomainHeader, options.domain);
-            }
-            if (csrfToken) {
-                xhr.setRequestHeader(csrfHeader, csrfToken);
             }
         };
 

--- a/web/dev/scripts/rdapi.js
+++ b/web/dev/scripts/rdapi.js
@@ -191,28 +191,9 @@ function (require,   $,        object,         jig,         friendly,   isoDate)
                 }
             },
             error: function (xhr, textStatus, errorThrown) {
-                var retrySeconds = xhr.status === 503 &&
-                                   xhr.getResponseHeader('Retry-After'),
-                    html;
-
-                if (retrySeconds) {
-                    retrySeconds = parseInt(retrySeconds, 10);
-                    if (isNaN(retrySeconds)) {
-                        retrySeconds = null;
-                    }
-                }
-
                 if (options.emptyTemplate) {
-                    html = jig(options.emptyTemplate, errorThrown, options);
+                    var html = jig(options.emptyTemplate, errorThrown, options);
                     finishApiTemplating(html, options);
-                } else if (retrySeconds) {
-                    // TODO: Need to flesh this out a bit more, may need
-                    // to pause and show some UI before automatically retrying,
-                    // depending on the outcome of bug
-                    // https://bugzilla.mozilla.org/show_bug.cgi?id=642653
-                    setTimeout(function () {
-                        ajax(url, options);
-                    }, retrySeconds * 1000);
                 } else {
                     throw errorThrown;
                 }

--- a/web/dev/share/panel/index.js
+++ b/web/dev/share/panel/index.js
@@ -195,6 +195,7 @@ function (require,   $,        object,         fn,         rdapi,   oauth,
   function callSendApi() {
     rdapi('send', {
       type: 'POST',
+      domain: sendData.domain,
       data: sendData,
       success: function (json) {
         // {'message': u'Status is a duplicate.', 'provider': u'twitter.com'}

--- a/web/dev/share/panel/index.js
+++ b/web/dev/share/panel/index.js
@@ -238,7 +238,9 @@ function (require,   $,        object,         fn,         rdapi,   oauth,
           //var headerError = xhr.getResponseHeader('X-Error');
           reAuth();
         } else if (xhr.status === 503) {
-          showStatus('statusServerBusy');
+          dispatch.pub('serverErrorPossibleRetry', {
+            xhr: xhr
+          });
         } else if (xhr.status === 0) {
           showStatus('statusServerError');
         } else {
@@ -455,6 +457,13 @@ function (require,   $,        object,         fn,         rdapi,   oauth,
     //Listen to sendMessage events from the AccountPanels
     dispatch.sub('sendMessage', function (data) {
       sendMessage(data);
+    });
+
+    // Listen for 503 errors, could be a retry call, but for
+    // now, just show server error until better feedback is
+    // worked out in https://bugzilla.mozilla.org/show_bug.cgi?id=642653
+    dispatch.sub('serverErrorPossibleRetry', function (data) {
+      showStatus('statusServerBusy');
     });
 
     bodyDom = $('body');


### PR DESCRIPTION
Initial support for X-Target-Domain and Retry-After for API calls. Needs more UX input for dealing with Retry-After, but this is a good first start, and will allow switching to the new server approach.

I want to add some tests too, so I do not want to close out the bug yet if this pull request is merged. However, pushing this change will allow the FE to work with the new server approach. Testing is also dependent on working out a mock server model for the UI, and I'm not sure how that will work yet in the new server approach: will some python process still serve the UI in dev, and if so, how can I hook up some mock servers that return error codes and custom headers?
