### PR TITLE
bug 654598 add `make dev` target for development builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ endif
 
 APPNAME = server-shared-send
 DEPS = mozilla:server-core,github:server-share-core
+DEV_DEPS = github:server-core,github:server-share-core
 VIRTUALENV = virtualenv
 NOSE = $(BIN_DIR)/nosetests
 NOSETESTS_ARGS = -s
@@ -118,6 +119,15 @@ f1.spec: f1.spec.in Makefile tools/makespec
 build:
 	$(VIRTUALENV) --no-site-packages --distribute .
 	$(PYTHON) build.py $(APPNAME) $(DEPS)
+	$(EZ) nose
+	$(EZ) WebTest
+	$(EZ) Funkload
+	$(EZ) pylint
+	$(EZ) coverage
+
+dev:
+	$(VIRTUALENV) --no-site-packages --distribute .
+	$(PYTHON) build.py $(APPNAME) $(DEV_DEPS)
 	$(EZ) nose
 	$(EZ) WebTest
 	$(EZ) Funkload


### PR DESCRIPTION
add DEV_DEPS value and a `dev` target that is exactly like `build` except it
used DEV_DEPS instead of DEPS
